### PR TITLE
feat: Add descriptive alt text for each flag

### DIFF
--- a/components/search.njk
+++ b/components/search.njk
@@ -64,6 +64,7 @@
 					data-patterns="{{ flag.patterns }}"
 				>
 					{% set width = 131 %}
+					{% set descriptionID = id ~ "-flag-description" %}
 					<img
 						class="Search-itemFlag"
 						src="/img/{{ id }}.svg"
@@ -71,13 +72,13 @@
 						width="{{ width }}"
 						height="{{ (width / flag.aspect_ratio)|round }}"
 						loading="lazy"
-						{% if flag.flagAlt %}
-						aria-describedby="{{ id }}-flag-description"
+						{% if flag.alt %}
+							aria-describedby="{{ descriptionID }}"
 						{% endif %}
 					>
 					<a class="Search-itemLink" href="/{{ id }}/">{{ flag.name }}</a>
-					{% if flag.flagAlt %}
-					<p hidden id="{{ id }}-flag-description">{{ flag.flagAlt }}</p>
+					{% if flag.alt %}
+						<p id="{{ descriptionID }}" hidden>{{ flag.alt }}</p>
 					{% endif %}
 				</li>
 			{% endfor %}

--- a/components/search.njk
+++ b/components/search.njk
@@ -71,9 +71,14 @@
 						width="{{ width }}"
 						height="{{ (width / flag.aspect_ratio)|round }}"
 						loading="lazy"
+						{% if flag.flagAlt %}
+						aria-describedby="{{ id }}-flag-description"
+						{% endif %}
 					>
-
 					<a class="Search-itemLink" href="/{{ id }}/">{{ flag.name }}</a>
+					{% if flag.flagAlt %}
+					<p hidden id="{{ id }}-flag-description">{{ flag.flagAlt }}</p>
+					{% endif %}
 				</li>
 			{% endfor %}
 		</ul>

--- a/data/flags/abrosexuality.yaml
+++ b/data/flags/abrosexuality.yaml
@@ -12,3 +12,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: green, pale green, white, light pink, darker pink."

--- a/data/flags/abrosexuality.yaml
+++ b/data/flags/abrosexuality.yaml
@@ -12,4 +12,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: green, pale green, white, light pink, darker pink."
+alt: "5 horizontal stripes. From top to bottom: green, pale green, white, light pink, darker pink."

--- a/data/flags/achillean.yaml
+++ b/data/flags/achillean.yaml
@@ -16,4 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "A light blue field with a white horizontal stripe running down the middle. In the center of the stripe, there is a green carnation motif."
+alt: A light blue field with a white horizontal stripe running down the middle. In the center of the stripe, there is a green carnation motif.

--- a/data/flags/achillean.yaml
+++ b/data/flags/achillean.yaml
@@ -16,3 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "A light blue field with a white horizontal stripe running down the middle. In the center of the stripe, there is a green carnation motif."

--- a/data/flags/agender.yaml
+++ b/data/flags/agender.yaml
@@ -18,3 +18,4 @@ colors:
   - green
 patterns:
   - stripes_horizontal
+flagAlt: "7 horizontal stripes. From top to bottom: black, gray, white, light green, white, gray, black."

--- a/data/flags/agender.yaml
+++ b/data/flags/agender.yaml
@@ -18,4 +18,4 @@ colors:
   - green
 patterns:
   - stripes_horizontal
-flagAlt: "7 horizontal stripes. From top to bottom: black, gray, white, light green, white, gray, black."
+alt: "7 horizontal stripes. From top to bottom: black, gray, white, light green, white, gray, black."

--- a/data/flags/ally.yaml
+++ b/data/flags/ally.yaml
@@ -21,4 +21,4 @@ patterns:
   - chevron
   - stripes_horizontal
   - symbol
-flagAlt: 6 horizontal stripes alternate black and white. A large, upward-pointing, rainbow-striped chevron, resembling a capital A, is overlaid.
+alt: 6 horizontal stripes alternate black and white. A large, upward-pointing, rainbow-striped chevron, resembling a capital A, is overlaid.

--- a/data/flags/ally.yaml
+++ b/data/flags/ally.yaml
@@ -21,3 +21,4 @@ patterns:
   - chevron
   - stripes_horizontal
   - symbol
+flagAlt: 6 horizontal stripes alternate black and white. A large, upward-pointing, rainbow-striped chevron, resembling a capital A, is overlaid.

--- a/data/flags/ambiamory.yaml
+++ b/data/flags/ambiamory.yaml
@@ -16,3 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: Horizontal stripes fade from blue to black to red. In the center of the flag, there is a white lowercase alpha.

--- a/data/flags/ambiamory.yaml
+++ b/data/flags/ambiamory.yaml
@@ -16,4 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: Horizontal stripes fade from blue to black to red. In the center of the flag, there is a white lowercase alpha.
+alt: Horizontal stripes fade from blue to black to red. In the center of the flag, there is a white lowercase alpha.

--- a/data/flags/aroace.yaml
+++ b/data/flags/aroace.yaml
@@ -16,4 +16,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: orange, yellow, white, light blue, dark blue."
+alt: "5 horizontal stripes. From top to bottom: orange, yellow, white, light blue, dark blue."

--- a/data/flags/aroace.yaml
+++ b/data/flags/aroace.yaml
@@ -16,3 +16,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: orange, yellow, white, light blue, dark blue."

--- a/data/flags/aromanticism.yaml
+++ b/data/flags/aromanticism.yaml
@@ -16,4 +16,4 @@ colors:
   - black
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: green, light green, white, gray, black."
+alt: "5 horizontal stripes. From top to bottom: green, light green, white, gray, black."

--- a/data/flags/aromanticism.yaml
+++ b/data/flags/aromanticism.yaml
@@ -16,3 +16,4 @@ colors:
   - black
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: green, light green, white, gray, black."

--- a/data/flags/asexuality.yaml
+++ b/data/flags/asexuality.yaml
@@ -16,4 +16,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
-flagAlt: "4 horizontal stripes. From top to bottom: black, gray, white, purple."
+alt: "4 horizontal stripes. From top to bottom: black, gray, white, purple."

--- a/data/flags/asexuality.yaml
+++ b/data/flags/asexuality.yaml
@@ -16,3 +16,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
+flagAlt: "4 horizontal stripes. From top to bottom: black, gray, white, purple."

--- a/data/flags/bear.yaml
+++ b/data/flags/bear.yaml
@@ -16,4 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "7 horizontal stripes features browns, yellows, and grays. In the top left corner, there's a bear pawprint."
+flagAlt: "7 horizontal stripes featuring browns, yellows, and grays. In the top left corner, there's a bear pawprint."

--- a/data/flags/bear.yaml
+++ b/data/flags/bear.yaml
@@ -16,3 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "7 horizontal stripes features browns, yellows, and grays. In the top left corner, there's a bear pawprint."

--- a/data/flags/bear.yaml
+++ b/data/flags/bear.yaml
@@ -16,4 +16,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "7 horizontal stripes featuring browns, yellows, and grays. In the top left corner, there's a bear pawprint."
+alt: 7 horizontal stripes featuring browns, yellows, and grays. In the top left corner, there is a bear pawprint.

--- a/data/flags/bi-curious.yaml
+++ b/data/flags/bi-curious.yaml
@@ -14,3 +14,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "7 horizontal stripes fade from bright pink at the top to white to blue at the bottom."

--- a/data/flags/bi-curious.yaml
+++ b/data/flags/bi-curious.yaml
@@ -14,4 +14,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "7 horizontal stripes fade from bright pink at the top to white to blue at the bottom."
+alt: 7 horizontal stripes fade from bright pink at the top to white to blue at the bottom.

--- a/data/flags/bigender.yaml
+++ b/data/flags/bigender.yaml
@@ -16,3 +16,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "7 horizontal, pastel stripes. From top to bottom: two light pink stripes, a lavender stripe, a white stripe, another lavender stripe, and two blue stripes."

--- a/data/flags/bigender.yaml
+++ b/data/flags/bigender.yaml
@@ -16,4 +16,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "7 horizontal, pastel stripes. From top to bottom: two light pink stripes, a lavender stripe, a white stripe, another lavender stripe, and two blue stripes."
+alt: "7 horizontal, pastel stripes. From top to bottom: two light pink stripes, a lavender stripe, a white stripe, another lavender stripe, and two blue stripes."

--- a/data/flags/bisexuality.yaml
+++ b/data/flags/bisexuality.yaml
@@ -12,3 +12,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: a thick magenta stripe, a thin purple stripe, and a thick blue stripe."

--- a/data/flags/bisexuality.yaml
+++ b/data/flags/bisexuality.yaml
@@ -12,4 +12,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: a thick magenta stripe, a thin purple stripe, and a thick blue stripe."
+alt: "3 horizontal stripes. From top to bottom: a thick magenta stripe, a thin purple stripe, and a thick blue stripe."

--- a/data/flags/cinthean.yaml
+++ b/data/flags/cinthean.yaml
@@ -13,4 +13,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: "6 hotizontal stripes. From top to bottom: navy blue, purple, red, light pink, light orange, white."
+alt: "6 hotizontal stripes. From top to bottom: navy blue, purple, red, light pink, light orange, white."

--- a/data/flags/cinthean.yaml
+++ b/data/flags/cinthean.yaml
@@ -13,3 +13,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: "6 hotizontal stripes. From top to bottom: navy blue, purple, red, light pink, light orange, white."

--- a/data/flags/demiboy.yaml
+++ b/data/flags/demiboy.yaml
@@ -17,3 +17,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: "7 horizontal stripes. From top to bottom: gray, light gray, light blue, white, light blue, light gray, gray."

--- a/data/flags/demiboy.yaml
+++ b/data/flags/demiboy.yaml
@@ -17,4 +17,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: "7 horizontal stripes. From top to bottom: gray, light gray, light blue, white, light blue, light gray, gray."
+alt: "7 horizontal stripes. From top to bottom: gray, light gray, light blue, white, light blue, light gray, gray."

--- a/data/flags/demigirl.yaml
+++ b/data/flags/demigirl.yaml
@@ -19,3 +19,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: "7 horizontal stripes. From top to bottom: gray, light gray, light pink, white, light pink, light gray, gray."

--- a/data/flags/demigirl.yaml
+++ b/data/flags/demigirl.yaml
@@ -19,4 +19,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: "7 horizontal stripes. From top to bottom: gray, light gray, light pink, white, light pink, light gray, gray."
+alt: "7 horizontal stripes. From top to bottom: gray, light gray, light pink, white, light pink, light gray, gray."

--- a/data/flags/demiromaticism.yaml
+++ b/data/flags/demiromaticism.yaml
@@ -14,3 +14,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "3 horizontal stripes. From top to bottom: a large white stripe, a thin green stripe, and a large gray stripe. On the left side of the flag, a large black chevron points to the right."

--- a/data/flags/demiromaticism.yaml
+++ b/data/flags/demiromaticism.yaml
@@ -14,4 +14,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "3 horizontal stripes. From top to bottom: a large white stripe, a thin green stripe, and a large gray stripe. On the left side of the flag, a large black chevron points to the right."
+alt: "3 horizontal stripes. From top to bottom: a large white stripe, a thin green stripe, and a large gray stripe. On the left side of the flag, a large black chevron points to the right."

--- a/data/flags/demisexuality.yaml
+++ b/data/flags/demisexuality.yaml
@@ -14,4 +14,4 @@ colors:
 patterns:
   - chevron
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: a large white stripe, a thin purple stripe, and a large gray stripe. On the left side of the flag, a large black chevron points to the right."
+alt: "3 horizontal stripes. From top to bottom: a large white stripe, a thin purple stripe, and a large gray stripe. On the left side of the flag, a large black chevron points to the right."

--- a/data/flags/demisexuality.yaml
+++ b/data/flags/demisexuality.yaml
@@ -14,3 +14,4 @@ colors:
 patterns:
   - chevron
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: a large white stripe, a thin purple stripe, and a large gray stripe. On the left side of the flag, a large black chevron points to the right."

--- a/data/flags/disability-pride.yaml
+++ b/data/flags/disability-pride.yaml
@@ -14,4 +14,4 @@ colors:
 patterns:
   - solid
   - stripes_diagonal
-flagAlt: A gray field. A band of pastel stripes (red, yellow, white, blue, green) stretches diagonally from the top left corner to the bottom right corner.
+alt: A gray field. A band of pastel stripes (red, yellow, white, blue, green) stretches diagonally from the top left corner to the bottom right corner.

--- a/data/flags/disability-pride.yaml
+++ b/data/flags/disability-pride.yaml
@@ -14,3 +14,4 @@ colors:
 patterns:
   - solid
   - stripes_diagonal
+flagAlt: A gray field. A band of pastel stripes (red, yellow, white, blue, green) stretches diagonally from the top left corner to the bottom right corner.

--- a/data/flags/disability.yaml
+++ b/data/flags/disability.yaml
@@ -12,3 +12,4 @@ colors:
   - orange
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: yellow, light gray, orange."

--- a/data/flags/disability.yaml
+++ b/data/flags/disability.yaml
@@ -12,4 +12,4 @@ colors:
   - orange
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: yellow, light gray, orange."
+alt: "3 horizontal stripes. From top to bottom: yellow, light gray, orange."

--- a/data/flags/drag.yaml
+++ b/data/flags/drag.yaml
@@ -14,4 +14,4 @@ colors:
 patterns:
   - symbol
   - stripes_vertical
-flagAlt: "3 vertical stripes: purple, white, blue. In the center of the white stripe, there is a pink crown."
+alt: "3 vertical stripes: purple, white, blue. In the center of the white stripe, there is a pink crown."

--- a/data/flags/drag.yaml
+++ b/data/flags/drag.yaml
@@ -14,3 +14,4 @@ colors:
 patterns:
   - symbol
   - stripes_vertical
+flagAlt: "3 vertical stripes: purple, white, blue. In the center of the white stripe, there is a pink crown."

--- a/data/flags/enbian.yaml
+++ b/data/flags/enbian.yaml
@@ -17,3 +17,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "5 horizontal stripes range from black to dark purple to light purple. In the center of the flag, there is a yellow crescent moon. A white circle is nestled inside of the moon."

--- a/data/flags/enbian.yaml
+++ b/data/flags/enbian.yaml
@@ -17,4 +17,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "5 horizontal stripes range from black to dark purple to light purple. In the center of the flag, there is a yellow crescent moon. A white circle is nestled inside of the moon."
+alt: 5 horizontal stripes range from black to dark purple to light purple. In the center of the flag, there is a yellow crescent moon. A white circle is nestled inside of the moon.

--- a/data/flags/gay.yaml
+++ b/data/flags/gay.yaml
@@ -15,3 +15,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: teal, light green, white, light blue, dark blue."

--- a/data/flags/gay.yaml
+++ b/data/flags/gay.yaml
@@ -15,4 +15,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: teal, light green, white, light blue, dark blue."
+alt: "5 horizontal stripes. From top to bottom: teal, light green, white, light blue, dark blue."

--- a/data/flags/gender-fluidity.yaml
+++ b/data/flags/gender-fluidity.yaml
@@ -16,4 +16,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: pink, white, purple, black, blue."
+alt: "5 horizontal stripes. From top to bottom: pink, white, purple, black, blue."

--- a/data/flags/gender-fluidity.yaml
+++ b/data/flags/gender-fluidity.yaml
@@ -16,3 +16,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: pink, white, purple, black, blue."

--- a/data/flags/gender-non-conforming.yaml
+++ b/data/flags/gender-non-conforming.yaml
@@ -17,3 +17,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: "A dark plum field. A horizontal band runs down the middle, comprised of light plum, blue, white, blue, and light plum stripes."

--- a/data/flags/gender-non-conforming.yaml
+++ b/data/flags/gender-non-conforming.yaml
@@ -17,4 +17,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: "A dark plum field. A horizontal band runs down the middle, comprised of light plum, blue, white, blue, and light plum stripes."
+alt: A dark plum field. A horizontal band runs down the middle, comprised of light plum, blue, white, blue, and light plum stripes.

--- a/data/flags/genderqueer.yaml
+++ b/data/flags/genderqueer.yaml
@@ -12,3 +12,4 @@ colors:
   - green
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: lavender, white, green."

--- a/data/flags/genderqueer.yaml
+++ b/data/flags/genderqueer.yaml
@@ -12,4 +12,4 @@ colors:
   - green
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: lavender, white, green."
+alt: "3 horizontal stripes. From top to bottom: lavender, white, green."

--- a/data/flags/gray-asexuality.yaml
+++ b/data/flags/gray-asexuality.yaml
@@ -17,4 +17,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: purple, gray, white, gray, purple."
+alt: "5 horizontal stripes. From top to bottom: purple, gray, white, gray, purple."

--- a/data/flags/gray-asexuality.yaml
+++ b/data/flags/gray-asexuality.yaml
@@ -17,3 +17,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: purple, gray, white, gray, purple."

--- a/data/flags/heterosexuality.yaml
+++ b/data/flags/heterosexuality.yaml
@@ -14,3 +14,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: blue, white, pink."

--- a/data/flags/heterosexuality.yaml
+++ b/data/flags/heterosexuality.yaml
@@ -14,4 +14,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: blue, white, pink."
+alt: "3 horizontal stripes. From top to bottom: blue, white, pink."

--- a/data/flags/intersex.yaml
+++ b/data/flags/intersex.yaml
@@ -12,3 +12,4 @@ colors:
 patterns:
   - solid
   - symbol
+flagAlt: A yellow field with a purple ring in the center.

--- a/data/flags/intersex.yaml
+++ b/data/flags/intersex.yaml
@@ -12,4 +12,4 @@ colors:
 patterns:
   - solid
   - symbol
-flagAlt: A yellow field with a purple ring in the center.
+alt: A yellow field with a purple ring in the center.

--- a/data/flags/leather.yaml
+++ b/data/flags/leather.yaml
@@ -14,4 +14,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "Horizontal stripes alternate between black and blue, with one white stripe in the middle. A red heart is in the top left corner."
+alt: Horizontal stripes alternate between black and blue, with one white stripe in the middle. A red heart is in the top left corner.

--- a/data/flags/leather.yaml
+++ b/data/flags/leather.yaml
@@ -14,3 +14,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "Horizontal stripes alternate between black and blue, with one white stripe in the middle. A red heart is in the top left corner."

--- a/data/flags/lesbian.yaml
+++ b/data/flags/lesbian.yaml
@@ -15,4 +15,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: dark orange, light orange, white, light pink, dark pink."
+alt: "5 horizontal stripes. From top to bottom: dark orange, light orange, white, light pink, dark pink."

--- a/data/flags/lesbian.yaml
+++ b/data/flags/lesbian.yaml
@@ -15,3 +15,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: dark orange, light orange, white, light pink, dark pink."

--- a/data/flags/maverique.yaml
+++ b/data/flags/maverique.yaml
@@ -10,3 +10,4 @@ colors:
   - orange
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: yellow, white, orange."

--- a/data/flags/maverique.yaml
+++ b/data/flags/maverique.yaml
@@ -10,4 +10,4 @@ colors:
   - orange
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: yellow, white, orange."
+alt: "3 horizontal stripes. From top to bottom: yellow, white, orange."

--- a/data/flags/multisexuality.yaml
+++ b/data/flags/multisexuality.yaml
@@ -15,4 +15,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
-flagAlt: "4 horizontal stripes. From top to bottom: purple, white, light blue, pink."
+alt: "4 horizontal stripes. From top to bottom: purple, white, light blue, pink."

--- a/data/flags/multisexuality.yaml
+++ b/data/flags/multisexuality.yaml
@@ -15,3 +15,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
+flagAlt: "4 horizontal stripes. From top to bottom: purple, white, light blue, pink."

--- a/data/flags/neutrois.yaml
+++ b/data/flags/neutrois.yaml
@@ -12,3 +12,4 @@ colors:
   - black
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: white, green, black."

--- a/data/flags/neutrois.yaml
+++ b/data/flags/neutrois.yaml
@@ -12,4 +12,4 @@ colors:
   - black
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: white, green, black."
+alt: "3 horizontal stripes. From top to bottom: white, green, black."

--- a/data/flags/non-binary.yaml
+++ b/data/flags/non-binary.yaml
@@ -16,4 +16,4 @@ colors:
   - black
 patterns:
   - stripes_horizontal
-flagAlt: "4 horizontal stripes. From top to bottom: yellow, white, purple, black."
+alt: "4 horizontal stripes. From top to bottom: yellow, white, purple, black."

--- a/data/flags/non-binary.yaml
+++ b/data/flags/non-binary.yaml
@@ -16,3 +16,4 @@ colors:
   - black
 patterns:
   - stripes_horizontal
+flagAlt: "4 horizontal stripes. From top to bottom: yellow, white, purple, black."

--- a/data/flags/omnisexuality.yaml
+++ b/data/flags/omnisexuality.yaml
@@ -14,4 +14,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: light pink, bright pink, dark purple, blue, light blue."
+alt: "5 horizontal stripes. From top to bottom: light pink, bright pink, dark purple, blue, light blue."

--- a/data/flags/omnisexuality.yaml
+++ b/data/flags/omnisexuality.yaml
@@ -14,3 +14,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: light pink, bright pink, dark purple, blue, light blue."

--- a/data/flags/pangender.yaml
+++ b/data/flags/pangender.yaml
@@ -16,3 +16,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: 7 horizontal stripes fade from pastel yellow, to pastel pink, to white, to pastel pink, to pastel yellow.

--- a/data/flags/pangender.yaml
+++ b/data/flags/pangender.yaml
@@ -16,4 +16,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: 7 horizontal stripes fade from pastel yellow, to pastel pink, to white, to pastel pink, to pastel yellow.
+alt: 7 horizontal stripes fade from pastel yellow, to pastel pink, to white, to pastel pink, to pastel yellow.

--- a/data/flags/pansexuality.yaml
+++ b/data/flags/pansexuality.yaml
@@ -14,3 +14,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: magenta, yellow, cyan."

--- a/data/flags/pansexuality.yaml
+++ b/data/flags/pansexuality.yaml
@@ -14,4 +14,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: magenta, yellow, cyan."
+alt: "3 horizontal stripes. From top to bottom: magenta, yellow, cyan."

--- a/data/flags/peace-lettering.yaml
+++ b/data/flags/peace-lettering.yaml
@@ -17,4 +17,4 @@ colors:
 patterns:
   - lettering
   - stripes_horizontal
-flagAlt: "7 horizontal stripes make a rainbow, from purple down to red. In the center of the flag, white lettering reads: PACE."
+alt: "7 horizontal stripes make a rainbow, from purple down to red. In the center of the flag, white lettering reads: PACE."

--- a/data/flags/peace-lettering.yaml
+++ b/data/flags/peace-lettering.yaml
@@ -17,3 +17,4 @@ colors:
 patterns:
   - lettering
   - stripes_horizontal
+flagAlt: "7 horizontal stripes make a rainbow, from purple down to red. In the center of the flag, white lettering reads: PACE."

--- a/data/flags/peace-symbol.yaml
+++ b/data/flags/peace-symbol.yaml
@@ -17,3 +17,4 @@ colors:
 patterns:
   - symbol
   - stripes_horizontal
+flagAlt: "7 horizontal stripes make a rainbow, from purple down to red. In the center of the flag, there is a large white peace symbol."

--- a/data/flags/peace-symbol.yaml
+++ b/data/flags/peace-symbol.yaml
@@ -17,4 +17,4 @@ colors:
 patterns:
   - symbol
   - stripes_horizontal
-flagAlt: "7 horizontal stripes make a rainbow, from purple down to red. In the center of the flag, there is a large white peace symbol."
+alt: 7 horizontal stripes make a rainbow, from purple down to red. In the center of the flag, there is a large white peace symbol.

--- a/data/flags/pluralian.yaml
+++ b/data/flags/pluralian.yaml
@@ -12,3 +12,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: A purple field with a horizontal white stripe running down the middle. In the center, there's a yellow and green lily motif.

--- a/data/flags/pluralian.yaml
+++ b/data/flags/pluralian.yaml
@@ -12,4 +12,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: A purple field with a horizontal white stripe running down the middle. In the center, there's a yellow and green lily motif.
+alt: A purple field with a horizontal white stripe running down the middle. In the center, there is a yellow and green lily motif.

--- a/data/flags/polyamory.yaml
+++ b/data/flags/polyamory.yaml
@@ -19,3 +19,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "3 horizontal stripes. From top to bottom: sky blue, bright red, dark purple. On the left side, a white chevron, aligned closer to the top of the flag, points to the right. Inside the chevron, a yellow heart lays on its side, also pointing to the right."

--- a/data/flags/polyamory.yaml
+++ b/data/flags/polyamory.yaml
@@ -19,4 +19,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "3 horizontal stripes. From top to bottom: sky blue, bright red, dark purple. On the left side, a white chevron, aligned closer to the top of the flag, points to the right. Inside the chevron, a yellow heart lays on its side, also pointing to the right."
+alt: "3 horizontal stripes. From top to bottom: sky blue, bright red, dark purple. On the left side, a white chevron, aligned closer to the top of the flag, points to the right. Inside the chevron, a yellow heart lays on its side, also pointing to the right."

--- a/data/flags/polysexuality.yaml
+++ b/data/flags/polysexuality.yaml
@@ -12,3 +12,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: "3 horizontal stripes. From top to bottom: bright pink, bright green, sky blue."

--- a/data/flags/polysexuality.yaml
+++ b/data/flags/polysexuality.yaml
@@ -12,4 +12,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: "3 horizontal stripes. From top to bottom: bright pink, bright green, sky blue."
+alt: "3 horizontal stripes. From top to bottom: bright pink, bright green, sky blue."

--- a/data/flags/progress-pride-2018.yaml
+++ b/data/flags/progress-pride-2018.yaml
@@ -19,4 +19,4 @@ colors:
 patterns:
   - chevron
   - stripes_horizontal
-flagAlt: "6 rainbow horizontal stripes. In the left third, a large chevron points right, comprised of a black and brown stripe, as well as a light blue, light pink, and white stripe reminiscent of the transgender pride flag."
+alt: 6 rainbow horizontal stripes. In the left third, a large chevron points right, comprised of a black and brown stripe, as well as a light blue, light pink, and white stripe reminiscent of the transgender pride flag.

--- a/data/flags/progress-pride-2018.yaml
+++ b/data/flags/progress-pride-2018.yaml
@@ -19,3 +19,4 @@ colors:
 patterns:
   - chevron
   - stripes_horizontal
+flagAlt: "6 rainbow horizontal stripes. In the left third, a large chevron points right, comprised of a black and brown stripe, as well as a light blue, light pink, and white stripe reminiscent of the transgender pride flag."

--- a/data/flags/progress-pride-2021.yaml
+++ b/data/flags/progress-pride-2021.yaml
@@ -22,3 +22,4 @@ patterns:
   - chevron
   - stripes_horizontal
   - symbol
+flagAlt: "6 rainbow horizontal stripes. In the left third, a large chevron points right, comprised of a black and brown stripe, a light blue, light pink, and white stripe reminiscent of the transgender pride flag, and a yellow stripe with a purple ring reminiscent of the intersex pride flag."

--- a/data/flags/progress-pride-2021.yaml
+++ b/data/flags/progress-pride-2021.yaml
@@ -22,4 +22,4 @@ patterns:
   - chevron
   - stripes_horizontal
   - symbol
-flagAlt: "6 rainbow horizontal stripes. In the left third, a large chevron points right, comprised of a black and brown stripe, a light blue, light pink, and white stripe reminiscent of the transgender pride flag, and a yellow stripe with a purple ring reminiscent of the intersex pride flag."
+alt: 6 rainbow horizontal stripes. In the left third, a large chevron points right, comprised of a black and brown stripe, a light blue, light pink, and white stripe reminiscent of the transgender pride flag, and a yellow stripe with a purple ring reminiscent of the intersex pride flag.

--- a/data/flags/queer-anarchism.yaml
+++ b/data/flags/queer-anarchism.yaml
@@ -14,4 +14,4 @@ colors:
   - black
 patterns:
   - stripes_diagonal
-flagAlt: The top-left half is bright pink. The bottom-right half is black.
+alt: The top-left half is bright pink. The bottom-right half is black.

--- a/data/flags/queer-anarchism.yaml
+++ b/data/flags/queer-anarchism.yaml
@@ -14,3 +14,4 @@ colors:
   - black
 patterns:
   - stripes_diagonal
+flagAlt: The top-left half is bright pink. The bottom-right half is black.

--- a/data/flags/queer.yaml
+++ b/data/flags/queer.yaml
@@ -13,3 +13,4 @@ colors:
 patterns:
   - chevron
   - solid
+flagAlt: A white field. Two downward-pointing chevrons, one pink and one dark purple, span the width of the flag.

--- a/data/flags/queer.yaml
+++ b/data/flags/queer.yaml
@@ -13,4 +13,4 @@ colors:
 patterns:
   - chevron
   - solid
-flagAlt: A white field. Two downward-pointing chevrons, one pink and one dark purple, span the width of the flag.
+alt: A white field. Two downward-pointing chevrons, one pink and one dark purple, span the width of the flag.

--- a/data/flags/rainbow.yaml
+++ b/data/flags/rainbow.yaml
@@ -15,3 +15,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
+flagAlt: "6 horizontal stripes make a rainbow: red, orange, yellow, green, blue, purple."

--- a/data/flags/rainbow.yaml
+++ b/data/flags/rainbow.yaml
@@ -15,4 +15,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
-flagAlt: "6 horizontal stripes make a rainbow: red, orange, yellow, green, blue, purple."
+alt: "6 horizontal stripes make a rainbow: red, orange, yellow, green, blue, purple."

--- a/data/flags/sapphic.yaml
+++ b/data/flags/sapphic.yaml
@@ -17,4 +17,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: A pink field with a horizontal white stripe running down the middle. In the center, there's a purple and yellow violet motif.
+alt: A pink field with a horizontal white stripe running down the middle. In the center, there is a purple and yellow violet motif.

--- a/data/flags/sapphic.yaml
+++ b/data/flags/sapphic.yaml
@@ -17,3 +17,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: A pink field with a horizontal white stripe running down the middle. In the center, there's a purple and yellow violet motif.

--- a/data/flags/trans-man.yaml
+++ b/data/flags/trans-man.yaml
@@ -15,3 +15,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
+flagAlt: 7 horizontal stripes. The top and bottom stripes are pink. The middle stripes are all light blues.

--- a/data/flags/trans-man.yaml
+++ b/data/flags/trans-man.yaml
@@ -15,4 +15,4 @@ colors:
   - blue
 patterns:
   - stripes_horizontal
-flagAlt: 7 horizontal stripes. The top and bottom stripes are pink. The middle stripes are all light blues.
+alt: 7 horizontal stripes. The top and bottom stripes are pink. The middle stripes are all light blues.

--- a/data/flags/trans-woman.yaml
+++ b/data/flags/trans-woman.yaml
@@ -16,3 +16,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
+flagAlt: 7 horizontal stripes. The top and bottom stripes are light blue. The middle stripes are various shades of pink.

--- a/data/flags/trans-woman.yaml
+++ b/data/flags/trans-woman.yaml
@@ -16,4 +16,4 @@ colors:
   - pink
 patterns:
   - stripes_horizontal
-flagAlt: 7 horizontal stripes. The top and bottom stripes are light blue. The middle stripes are various shades of pink.
+alt: 7 horizontal stripes. The top and bottom stripes are light blue. The middle stripes are various shades of pink.

--- a/data/flags/transgender.yaml
+++ b/data/flags/transgender.yaml
@@ -14,4 +14,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: light blue, light pink, white, light pink, light blue."
+alt: "5 horizontal stripes. From top to bottom: light blue, light pink, white, light pink, light blue."

--- a/data/flags/transgender.yaml
+++ b/data/flags/transgender.yaml
@@ -14,3 +14,4 @@ colors:
   - white
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: light blue, light pink, white, light pink, light blue."

--- a/data/flags/trigender.yaml
+++ b/data/flags/trigender.yaml
@@ -12,4 +12,4 @@ colors:
   - green
 patterns:
   - stripes_horizontal
-flagAlt: "5 horizontal stripes. From top to bottom: light pink, lavender, green, lavender, light pink."
+alt: "5 horizontal stripes. From top to bottom: light pink, lavender, green, lavender, light pink."

--- a/data/flags/trigender.yaml
+++ b/data/flags/trigender.yaml
@@ -12,3 +12,4 @@ colors:
   - green
 patterns:
   - stripes_horizontal
+flagAlt: "5 horizontal stripes. From top to bottom: light pink, lavender, green, lavender, light pink."

--- a/data/flags/twink.yaml
+++ b/data/flags/twink.yaml
@@ -14,4 +14,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: "3 horizontal stripes. From top to bottom: pink, white, light yellow. In the center, there is a pair of black, interlinking Mars symbols."
+alt: "3 horizontal stripes. From top to bottom: pink, white, light yellow. In the center, there is a pair of black, interlinking Mars symbols."

--- a/data/flags/twink.yaml
+++ b/data/flags/twink.yaml
@@ -14,3 +14,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: "3 horizontal stripes. From top to bottom: pink, white, light yellow. In the center, there is a pair of black, interlinking Mars symbols."

--- a/data/flags/two-spirit.yaml
+++ b/data/flags/two-spirit.yaml
@@ -21,4 +21,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
-flagAlt: 6 horizontal stripes make a rainbow. In the center, a black and white motif depicts two feathers attached to a circle.
+alt: 6 horizontal stripes make a rainbow. In the center, a black and white motif depicts two feathers attached to a circle.

--- a/data/flags/two-spirit.yaml
+++ b/data/flags/two-spirit.yaml
@@ -21,3 +21,4 @@ colors:
 patterns:
   - stripes_horizontal
   - symbol
+flagAlt: 6 horizontal stripes make a rainbow. In the center, a black and white motif depicts two feathers attached to a circle.

--- a/data/flags/xenogender.yaml
+++ b/data/flags/xenogender.yaml
@@ -15,4 +15,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
-flagAlt: 7 horizontal stripes make a pastel rainbow.
+alt: 7 horizontal stripes make a pastel rainbow.

--- a/data/flags/xenogender.yaml
+++ b/data/flags/xenogender.yaml
@@ -15,3 +15,4 @@ colors:
   - purple
 patterns:
   - stripes_horizontal
+flagAlt: 7 horizontal stripes make a pastel rainbow.

--- a/pages/flag.njk
+++ b/pages/flag.njk
@@ -1,7 +1,8 @@
 {% set flag = flags[id] %}
-{% set flagAlt = flag.name + " flag" %}
-{% if flag.flagAlt %}
-{% set flagAlt = flag.name + " flag. " + flag.flagAlt %}
+{% set alt = flag.name ~ " flag" %}
+
+{% if flag.alt %}
+	{% set alt = flag.name ~ " flag. " ~ flag.alt %}
 {% endif %}
 
 {% if flag.aliases or flag.description %}
@@ -27,7 +28,7 @@
 	{% set width = 300 %}
 	<img
 		src="/img/{{ id }}.svg"
-		alt="{{ flagAlt }}"
+		alt="{{ alt }}"
 		width="{{ width }}"
 		height="{{ (width / flag.aspect_ratio)|round }}"
 	>

--- a/pages/flag.njk
+++ b/pages/flag.njk
@@ -1,4 +1,8 @@
 {% set flag = flags[id] %}
+{% set flagAlt = flag.name + " flag" %}
+{% if flag.flagAlt %}
+{% set flagAlt = flag.name + " flag. " + flag.flagAlt %}
+{% endif %}
 
 {% if flag.aliases or flag.description %}
 	<dl>
@@ -23,7 +27,7 @@
 	{% set width = 300 %}
 	<img
 		src="/img/{{ id }}.svg"
-		alt="{{ flag.name }} flag"
+		alt="{{ flagAlt }}"
 		width="{{ width }}"
 		height="{{ (width / flag.aspect_ratio)|round }}"
 	>

--- a/schemas/flag.yaml
+++ b/schemas/flag.yaml
@@ -60,3 +60,5 @@ properties:
         - stripes_horizontal
         - stripes_vertical
         - symbol
+  alt:
+    type: string


### PR DESCRIPTION
This is a wonderful project - thank you for putting it together!

Please feel free to reject this PR, but I thought it might be good to provide fuller alt text for each flag. To that end, I've added a `flagAlt` property to each flag's YAML data.

Then, when a flag's `flagAlt` is present:
- On the flag's page, the `flagAlt` is appended to the "{{ flagName }} flag" in the image's `alt`, such as "Abrosexuality flag. 5 horizontal stripes. From top to bottom: green, pale green, white, light pink, darker pink."
- On the homepage, since there are so many images, I've instead wired up each flag image to point to a hidden description node with `aria-describedby`.

Please let me know if there's anything you'd like me to change about this approach!